### PR TITLE
二要素認証設定画面に使ってたスタイル追加

### DIFF
--- a/src/components/_account-tab.scss
+++ b/src/components/_account-tab.scss
@@ -28,7 +28,7 @@
   cursor: pointer;
   color: var(--color-secondary-label);
   padding: 0 12px 0 12px;
-  &:hover {	
+  &:hover {
     color: var(--color-label);
   }
   @include mediaquery(tablet) {
@@ -54,7 +54,7 @@
 .controller-account-bank_accounts .ncgr-account-tab__list-item--bank-accounts,
 .controller-account-mail_receive_settings .ncgr-account-tab__list-item--mail-receive-settings,
 .controller-account-authorized_apps .ncgr-account-tab__list-item--authorized-apps,
-.controller-account-coupons .ncgr-account-tab__list-item--coupons,
+.controller-account-coupons .ncgr-account-tab__list-item--two-factor-authentication,
 .controller-account-facebook_dpa_feeds .ncgr-account-tab__list-item--facebook-dpa-feeds {
   &:first-child {
     .ncgr-account-tab__link {

--- a/src/components/_account-tab.scss
+++ b/src/components/_account-tab.scss
@@ -54,7 +54,7 @@
 .controller-account-bank_accounts .ncgr-account-tab__list-item--bank-accounts,
 .controller-account-mail_receive_settings .ncgr-account-tab__list-item--mail-receive-settings,
 .controller-account-authorized_apps .ncgr-account-tab__list-item--authorized-apps,
-.controller-account-two-factor-authentications .ncgr-account-tab__list-item--two-factor-authentications,
+.controller-account-two_factor_authentications .ncgr-account-tab__list-item--two-factor-authentications,
 .controller-account-facebook_dpa_feeds .ncgr-account-tab__list-item--facebook-dpa-feeds {
   &:first-child {
     .ncgr-account-tab__link {

--- a/src/components/_account-tab.scss
+++ b/src/components/_account-tab.scss
@@ -53,8 +53,8 @@
 .controller-account-profiles .ncgr-account-tab__list-item--profiles,
 .controller-account-bank_accounts .ncgr-account-tab__list-item--bank-accounts,
 .controller-account-mail_receive_settings .ncgr-account-tab__list-item--mail-receive-settings,
-.controller-account-authorized_apps .ncgr-account-tab__list-item--authorized-apps,
-.controller-account-coupons .ncgr-account-tab__list-item--two-factor-authentication,
+.controller-account-authorized_apps　.ncgr-account-tab__list-item--authorized-apps,
+.controller-account-two-factor-authentications .ncgr-account-tab__list-item--two-factor-authentications,
 .controller-account-facebook_dpa_feeds .ncgr-account-tab__list-item--facebook-dpa-feeds {
   &:first-child {
     .ncgr-account-tab__link {

--- a/src/components/_account-tab.scss
+++ b/src/components/_account-tab.scss
@@ -53,7 +53,7 @@
 .controller-account-profiles .ncgr-account-tab__list-item--profiles,
 .controller-account-bank_accounts .ncgr-account-tab__list-item--bank-accounts,
 .controller-account-mail_receive_settings .ncgr-account-tab__list-item--mail-receive-settings,
-.controller-account-authorized_apps　.ncgr-account-tab__list-item--authorized-apps,
+.controller-account-authorized_apps .ncgr-account-tab__list-item--authorized-apps,
 .controller-account-two-factor-authentications .ncgr-account-tab__list-item--two-factor-authentications,
 .controller-account-facebook_dpa_feeds .ncgr-account-tab__list-item--facebook-dpa-feeds {
   &:first-child {


### PR DESCRIPTION
https://git.pepabo.com/suzuri/suzuri/pull/6825

suzuri/suzuriの二要素認証のプルリクで、
app/assets/stylesheets/lib/nachiguro/components/_account-tab.scss
app/assets/stylesheets/lib/nachiguro/components/_card.scss
app/assets/stylesheets/lib/nachiguro/layout/_settings.scss
のファイルでコンフリクトが起きてて、ここと重複しているスタイルを消す作業をやってて、
app/assets/stylesheets/lib/nachiguro/components/_account-tab.scss
のスタイルをここのnachiguroに追加するの忘れてたので、追記しました！！！！

