### PR TITLE
Make expansion card arrow clickable

### DIFF
--- a/src/components/_expansion-card.scss
+++ b/src/components/_expansion-card.scss
@@ -103,6 +103,7 @@ category: Components
   position: absolute;
   right: 16px;
   top: 18px;
+  pointer-events: none;
 }
 
 .ncgr-expansion-card__checkbox:checked ~ .ncgr-expansion-card__arrow {


### PR DESCRIPTION
I added `pointer-event: none;` to the expansion card arrow.
It makes arrow clickable somehow..

<img width="403" alt="スクリーンショット 2020-04-02 18 02 55" src="https://user-images.githubusercontent.com/21121644/78230393-3a83e080-750c-11ea-89b5-1c31ef57bf42.png">
