### PR TITLE
Remove orange highlight on android chrome

### DIFF
--- a/src/components/_icon-button.scss
+++ b/src/components/_icon-button.scss
@@ -108,6 +108,8 @@ Icon Buttonはある商品やユーザー情報に対してアクションをす
   border: 1px solid var(--color-default-75);
   box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
   color: var(--color-danger-300);
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  outline: none;
   &:hover {
     border: 1px solid var(--color-default-200);
   }


### PR DESCRIPTION
This doesn't look cool.
(It only happens on android chrome.)

<img width="140" alt="スクリーンショット 2020-05-19 14 57 42" src="https://user-images.githubusercontent.com/21121644/82290113-1eb39b80-99e1-11ea-9c4d-db704fc4f06c.png">
