### PR TITLE
Fix nachiguro

### DIFF
--- a/src/components/_icon-button.scss
+++ b/src/components/_icon-button.scss
@@ -71,12 +71,13 @@ Icon Buttonはある商品やユーザー情報に対してアクションをす
   background-color: var(--color-default-900);
   color: var(--color-white);
   box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
-  border-color: var(--color-default-900);
+  border: 1px solid var(--color-default-900);
 }
 
 .ncgr-icon-button--white {
   background-color: var(--color-white);
   color: var(--color-default-500);
+  border: 1px solid var(--color-default-75);
 }
 
 .ncgr-icon-button--bordered {

--- a/src/components/_selectbox.scss
+++ b/src/components/_selectbox.scss
@@ -32,6 +32,7 @@ category: Components
   box-sizing: border-box;
   select {
     appearance: none;
+    -webkit-appearance: none;
     outline: 0;
     box-shadow: none;
     border: 0 !important;


### PR DESCRIPTION
Some of the components looked different from how it should look, so I fixed them.

Icon button needs to be specified solid property.
|before|after|
|---|---|
|<img width="716" alt="スクリーンショット 2020-06-24 19 13 40" src="https://user-images.githubusercontent.com/21121644/85537803-3f5db980-b64f-11ea-9ba3-2f6f9bda4471.png">|<img width="690" alt="スクリーンショット 2020-06-24 19 16 22" src="https://user-images.githubusercontent.com/21121644/85537787-3c62c900-b64f-11ea-9f53-409ac8efcc7d.png">|

I'm not sure why it didn't affect on production...

In nachiguro, autoprefixer didn't work somehow so I added
|before|after|
|---|---|
|<img width="674" alt="スクリーンショット 2020-06-24 19 19 39" src="https://user-images.githubusercontent.com/21121644/85538284-b430f380-b64f-11ea-8ff5-a9086ea70239.png">|<img width="670" alt="スクリーンショット 2020-06-24 19 19 48" src="https://user-images.githubusercontent.com/21121644/85538293-b6934d80-b64f-11ea-8702-22468a9bcad5.png">|
