### PR TITLE
add_.ncgr-modal--slide-enter-top

### DIFF
--- a/src/components/_modal.scss
+++ b/src/components/_modal.scss
@@ -29,6 +29,10 @@
   }
 }
 
+.ncgr-modal--slide-enter-top {
+  transform: translate3d(0, -100%, 0);
+}
+
 .ncgr-modal__inner {
   box-sizing: border-box;
   overflow-x: hidden;


### PR DESCRIPTION
add 'ncgr-modal--slide-enter-top'.

Using this class, the modal can appear from above.