### PR TITLE
Rename the container modifier

### DIFF
--- a/src/components/_container.scss
+++ b/src/components/_container.scss
@@ -97,7 +97,7 @@ $container-gaps: $gaps;
   }
 
   @each $container-width in map-keys($container-widths) {
-    &.-container-#{$container-width} {
+    &.-#{$container-width} {
       max-width: container-width($container-width);
     }
   }


### PR DESCRIPTION
Rename the container modifier because the current name is redundant.