### PR TITLE
Add ListTile to "word-break: break-all;"

### DIFF
--- a/src/components/_list-view.scss
+++ b/src/components/_list-view.scss
@@ -363,6 +363,7 @@ $list-view-gaps: $gaps;
   align-self: stretch;
   flex-grow: 1;
   min-height: 100%;
+  word-break: break-all;
 }
 
 .ncgr-list-tile__primary-title {


### PR DESCRIPTION
Fixed a problem with the appearance of the ListTile when a word goes on forever.

<img width="1680" alt="スクリーンショット 2020-12-23 16 33 32" src="https://user-images.githubusercontent.com/945841/102971386-a72c8880-453c-11eb-8ff0-08158de8e354.png">
