### PR TITLE
Fix Label Color

### DIFF
--- a/src/foundation/_color.scss
+++ b/src/foundation/_color.scss
@@ -400,7 +400,7 @@ category: Color
 
 :root {
   --color-label: var(--color-default-800);
-  --color-secondary-label: var(--color-default-200);
+  --color-secondary-label: var(--color-default-400);
   --color-placeholder-text: rgba(0, 0, 0, 0.2);
   --color-background: var(--color-white);
   --color-secondary-background: var(--color-default-50);

--- a/src/foundation/_color.scss
+++ b/src/foundation/_color.scss
@@ -423,7 +423,7 @@ category: Color
 @media (prefers-color-scheme: dark) {
   :root {
     --color-label: var(--color-white);
-    --color-secondary-label: var(--color-default-400);
+    --color-secondary-label: var(--color-default-200);
     --color-placeholder-text: rgba(255, 255, 255, 0.2);
     --color-background: var(--color-black);
     --color-secondary-background: var(--color-apple-dark-secondary);

--- a/src/foundation/_color.scss
+++ b/src/foundation/_color.scss
@@ -400,7 +400,7 @@ category: Color
 
 :root {
   --color-label: var(--color-default-900);
-  --color-secondary-label: var(--color-default-400);
+  --color-secondary-label: var(--color-default-300);
   --color-placeholder-text: rgba(0, 0, 0, 0.2);
   --color-background: var(--color-white);
   --color-secondary-background: var(--color-default-50);

--- a/src/foundation/_color.scss
+++ b/src/foundation/_color.scss
@@ -399,7 +399,7 @@ category: Color
 */
 
 :root {
-  --color-label: var(--color-default-800);
+  --color-label: var(--color-default-900);
   --color-secondary-label: var(--color-default-400);
   --color-placeholder-text: rgba(0, 0, 0, 0.2);
   --color-background: var(--color-white);

--- a/src/utility/_typography.scss
+++ b/src/utility/_typography.scss
@@ -11,8 +11,8 @@ category: Utility
 <div class="ncgr-typography-normal">Normal</div>
 <div class="ncgr-typography-bold">Bold</div>
 <div class="ncgr-typography-italic">Italic</div>
-<div class="ncgr-typography-light">Light</div>
 <div class="ncgr-typography-label">Label</div>
+<div class="ncgr-typography-secondary-label">Light</div>
 <div class="ncgr-typography-large">Large</div>
 <div class="ncgr-typography-medium">Medium</div>
 <div class="ncgr-typography-small">Small</div>
@@ -38,7 +38,7 @@ category: Utility
   color: var(--color-label);
 }
 
-.ncgr-typography-light {
+.ncgr-typography-secondary-label {
   color: var(--color-secondary-label);
 }
 


### PR DESCRIPTION
Secondary label color is too light, make it darker.
Since the difference between the Label Color and Secondary Label Color has been reduced, the Label Color has been darkened by one level.