### PR TITLE
Update List View Component

### DIFF
--- a/src/components/_list-view.scss
+++ b/src/components/_list-view.scss
@@ -10,28 +10,59 @@ category: Components
 リスト内の要素は、ユーザーアイコンなどの要素を配置できる`leading`と、テキスト用の`title`、アクションボタン等ほかの要素を配置できる`trailing`に分かれています。
 
 `text`には、PrimaryとSecondaryの二つの属性を持った文章を格納でき、これにより複数行のリストを作成することが可能です。
-タイトルが3行以上になる場合、`.ncgr-list-view`に`-three-line`のmodifierを付与してください。それにより`trailing`内の要素が適した位置に調整されます。
 
-また、リストの上下paddingを1remから0.5remに変更する`-dense`modifierが存在します。
+タイトルが2行になる場合、`.ncgr-list-view`に`-two-line`のmodifierを付与してください。それにより`leading`内の要素が適した位置に調整されます。
+
+タイトルが3行以上になる場合、`.ncgr-list-view`に`-multi-line`のmodifierを付与してください。それにより`leading`及び、`trailing`内の要素が適した位置に調整されます。
+
+また、`.ncgr-list-view`に`-dense`のmodifierを付与すると、リストの上下paddingが半分のサイズになります。
 
 
 ```example
 <section class="ncgr-list-group">
   <div class="ncgr-list-group__subheader">
-    One Line
+    One-line
   </div>
-  <ul class="ncgr-list-view -dense">
+  <ul class="ncgr-list-view">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Single-line item
+          One-line item
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          One-line item
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          One-line item
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <hr class="ncgr-list-divider">
+  <ul class="ncgr-list-view">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
         <div class="ncgr-list-tile__icon">
@@ -40,14 +71,52 @@ category: Components
       </div>
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Single-line item
+          One-line item
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-list-tile__icon">
+          <i class="fab fa-bluetooth-b"></i>
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          One-line item
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-list-tile__icon">
+          <i class="fab fa-bluetooth-b"></i>
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          One-line item
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <hr class="ncgr-list-divider">
+  <ul class="ncgr-list-view">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
         <div class="ncgr-avatar ncgr-avatar--medium">
@@ -56,50 +125,105 @@ category: Components
       </div>
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Single-line item
+          One-line item
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
-        <div class="ncgr-avatar ncgr-avatar--large">
+        <div class="ncgr-avatar ncgr-avatar--medium">
           <img class="ncgr-avatar__image" src="./images/components/avatar/avatar.png">
         </div>
       </div>
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Single-line item
+          One-line item
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-avatar ncgr-avatar--medium">
+          <img class="ncgr-avatar__image" src="./images/components/avatar/avatar.png">
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          One-line item
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
   </ul>
+  <hr class="ncgr-list-divider">
 </section>
 <section class="ncgr-list-group">
   <div class="ncgr-list-group__subheader">
-    Two Line
+    Two-line
   </div>
-  <ul class="ncgr-list-view">
+  <ul class="ncgr-list-view -two-line">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
           Two-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Two-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Two-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <hr class="ncgr-list-divider">
+  <ul class="ncgr-list-view -two-line">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
         <div class="ncgr-list-tile__icon">
@@ -111,14 +235,58 @@ category: Components
           Two-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-list-tile__icon">
+          <i class="fab fa-bluetooth-b"></i>
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Two-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-list-tile__icon">
+          <i class="fab fa-bluetooth-b"></i>
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Two-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <hr class="ncgr-list-divider">
+  <ul class="ncgr-list-view -two-line">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
         <div class="ncgr-avatar ncgr-avatar--medium">
@@ -130,53 +298,111 @@ category: Components
           Two-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
-        <div class="ncgr-avatar ncgr-avatar--large">
+        <div class="ncgr-avatar ncgr-avatar--medium">
           <img class="ncgr-avatar__image" src="./images/components/avatar/avatar.png">
         </div>
       </div>
       <div class="ncgr-list-tile__title">
-        <div class="ncgr-list-tile__primary-title">
+         <div class="ncgr-list-tile__primary-title">
           Two-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-avatar ncgr-avatar--medium">
+          <img class="ncgr-avatar__image" src="./images/components/avatar/avatar.png">
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+         <div class="ncgr-list-tile__primary-title">
+          Two-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
   </ul>
+  <hr class="ncgr-list-divider">
 </section>
 <section class="ncgr-list-group">
   <div class="ncgr-list-group__subheader">
-    Three Line
+    Multi-line
   </div>
-  <ul class="ncgr-list-view -list-large">
+  <ul class="ncgr-list-view -multi-line">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Three-line item
+          Multi-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text / Secondary text / Secondary text / Secondary text / Secondary text / Secondary text /
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Multi-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Multi-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <hr class="ncgr-list-divider">
+  <ul class="ncgr-list-view -multi-line">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
         <div class="ncgr-list-tile__icon">
@@ -185,17 +411,61 @@ category: Components
       </div>
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Three-line item
+          Multi-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text / Secondary text / Secondary text / Secondary text / Secondary text / Secondary text /
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-list-tile__icon">
+          <i class="fab fa-bluetooth-b"></i>
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Multi-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-list-tile__icon">
+          <i class="fab fa-bluetooth-b"></i>
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Multi-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <hr class="ncgr-list-divider">
+  <ul class="ncgr-list-view -multi-line">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
         <div class="ncgr-avatar ncgr-avatar--medium">
@@ -204,36 +474,60 @@ category: Components
       </div>
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Three-line item
+          Multi-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text / Secondary text / Secondary text / Secondary text / Secondary text / Secondary text /
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
-    <li role="separator" class="ncgr-list-divider">
     <li class="ncgr-list-tile">
       <div class="ncgr-list-tile__leading">
-        <div class="ncgr-avatar ncgr-avatar--large">
+        <div class="ncgr-avatar ncgr-avatar--medium">
           <img class="ncgr-avatar__image" src="./images/components/avatar/avatar.png">
         </div>
       </div>
       <div class="ncgr-list-tile__title">
         <div class="ncgr-list-tile__primary-title">
-          Three-line item
+          Multi-line item
         </div>
         <div class="ncgr-list-tile__secondary-title">
-          Secondary text / Secondary text / Secondary text / Secondary text / Secondary text / Secondary text /
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
       <div class="ncgr-list-tile__trailing">
-        <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
+      </div>
+    </li>
+    <li class="ncgr-list-tile">
+      <div class="ncgr-list-tile__leading">
+        <div class="ncgr-avatar ncgr-avatar--medium">
+          <img class="ncgr-avatar__image" src="./images/components/avatar/avatar.png">
+        </div>
+      </div>
+      <div class="ncgr-list-tile__title">
+        <div class="ncgr-list-tile__primary-title">
+          Multi-line item
+        </div>
+        <div class="ncgr-list-tile__secondary-title">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </div>
+      </div>
+      <div class="ncgr-list-tile__trailing">
+        <div class="ncgr-list-tile__icon">
+          <i class="fas fa-ellipsis-v ncgr-typography-light"></i>
+        </div>
       </div>
     </li>
   </ul>
+  <hr class="ncgr-list-divider">
 </section>
 ```
 
@@ -269,7 +563,17 @@ $list-view-gaps: $gaps;
 }
 
 .ncgr-list-group__subheader {
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1.5rem 0.5rem 1.5rem;
+  padding-top: 0.5rem;
+  padding-right: list-view-gap(s);
+  padding-bottom: 0.5rem;
+  padding-left: list-view-gap(s);
+  @each $list-view-boundary in map-keys($list-view-boundaries) {
+    @include mq-boundary-up($list-view-boundary) {
+      padding-right: list-view-gap($list-view-boundary);
+      padding-left: list-view-gap($list-view-boundary);
+    }
+  }
   font-size: 0.8rem;
   font-weight: bold;
 }
@@ -280,33 +584,51 @@ $list-view-gaps: $gaps;
   border: none;
   height: 1px;
   width: 100%;
-  margin: 0;
+  margin-top: list-view-gap(s) / 2;
+  margin-right: 0;
+  margin-bottom: list-view-gap(s) / 2;
+  margin-left: 0;
+  @each $list-view-boundary in map-keys($list-view-boundaries) {
+    @include mq-boundary-up($list-view-boundary) {
+      margin-top: list-view-gap($list-view-boundary) / 2;
+      margin-bottom: list-view-gap($list-view-boundary) / 2;
+    }
+  }
 }
 
 .ncgr-list-view {
+  box-sizing: border-box;
   width: 100%;
   height: auto;
-  padding: 0;
+  padding-top: 0;
+  padding-right: list-view-gap(s) / 2;
+  padding-bottom: 0;
+  padding-left: list-view-gap(s) / 2;
   margin: 0;
-  &.-three-line {
-    .ncgr-list-tile__trailing {
-      margin: 0 0 auto 1rem;
+  @each $list-view-boundary in map-keys($list-view-boundaries) {
+    @include mq-boundary-up($list-view-boundary) {
+      padding-right: list-view-gap($list-view-boundary) / 2;
+      padding-left: list-view-gap($list-view-boundary) / 2;
+    }
+  }
+  &.-two-line {
+    .ncgr-list-tile__leading {
+      align-self: flex-start;
+    }
+  }
+  &.-multi-line {
+    .ncgr-list-tile {
+      align-items: flex-start;
+    }
+    .ncgr-list-tile__secondary-title {
+      white-space: normal;
+      overflow: auto;
+      text-overflow: clip;
     }
   }
   &.-dense {
     .ncgr-list-tile {
-      padding-top: list-view-gap(s) / 2;
-      padding-right: list-view-gap(s);
-      padding-bottom: list-view-gap(s) / 2;
-      padding-left: list-view-gap(s);
-      @each $list-view-boundary in map-keys($list-view-boundaries) {
-        @include mq-boundary-up($list-view-boundary) {
-          padding-top: list-view-gap($list-view-boundary) / 2;
-          padding-right: list-view-gap($list-view-boundary);
-          padding-bottom: list-view-gap($list-view-boundary) / 2;
-          padding-left: list-view-gap($list-view-boundary);
-        }
-      }
+      padding: 0.5rem 0.5rem 0.5rem 0.5rem;
     }
   }
 }
@@ -317,37 +639,31 @@ $list-view-gaps: $gaps;
   line-height: 1.5;
   height: auto;
   display: flex;
-  align-items: flex-start;
-  padding-top: list-view-gap(s);
-  padding-right: list-view-gap(s);
-  padding-bottom: list-view-gap(s);
-  padding-left: list-view-gap(s);
-  cursor: pointer;
-  &:hover {
-    background: var(--color-secondary-background);
-  }
+  align-items: center;
+  padding: 1rem;
+  padding-top: 1rem;
+  padding-right: list-view-gap(s) / 2;
+  padding-bottom: 1rem;
+  padding-left: list-view-gap(s) / 2;
+  border-radius: 0.5rem;
   @each $list-view-boundary in map-keys($list-view-boundaries) {
     @include mq-boundary-up($list-view-boundary) {
-      padding-top: list-view-gap($list-view-boundary);
-      padding-right: list-view-gap($list-view-boundary);
-      padding-bottom: list-view-gap($list-view-boundary);
-      padding-left: list-view-gap($list-view-boundary);
+      padding-right: list-view-gap($list-view-boundary) / 2;
+      padding-left: list-view-gap($list-view-boundary) / 2;
     }
+  }
+  cursor: pointer;
+  &:hover,
+  &:active {
+    background: var(--color-tertiary-grouped-background);
   }
 }
 
 .ncgr-list-tile__leading {
-  width: auto;
-  height: auto;
-  display: flex;
-  align-items: flex-start;
-  min-width: 2.5rem;
-  margin: 0 1rem 0 0;
-  flex-shrink: 0;
+  width: 3.5rem;
 }
 
 .ncgr-list-tile__icon {
-  font-size: 1.5rem;
   width: 1.5rem;
   height: 1.5rem;
   display: flex;
@@ -356,31 +672,31 @@ $list-view-gaps: $gaps;
 }
 
 .ncgr-list-tile__title {
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-content: center;
-  align-self: stretch;
-  flex-grow: 1;
-  min-height: 100%;
+  flex: 1;
   word-break: break-all;
 }
 
 .ncgr-list-tile__primary-title {
   font-size: 1rem;
   color: var(--color-label);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ncgr-list-tile__secondary-title {
   font-size: 0.75rem;
   color: var(--color-secondary-label);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ncgr-list-tile__trailing {
-  min-width: 1.5rem;
-  height: 1.5rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: auto 0 auto 1rem;
+  box-sizing: border-box;
+  padding-left: 1rem;
 }


### PR DESCRIPTION
After applying the ListView component in various places, some problems with hovering became apparent, so I will fix it to fit in all places.

#### When combined with Grouped Background and Card, it will blend in with the background.

<table>
  <tr>
    <th>BEFORE</th>
    <th>AFTER</th>
  </tr>
  <tr>
    <td>
      <img width="1378" alt="スクリーンショット 2021-01-13 14 12 11" src="https://media.git.pepabo.com/user/140/files/c2257200-55a9-11eb-8203-00d726b7bcdc">
    </td>
    <td>
      <img width="1346" alt="スクリーンショット 2021-01-13 14 11 41" src="https://media.git.pepabo.com/user/140/files/c94c8000-55a9-11eb-9851-5c56bb5847a0">
    </td>
  </tr>
</table>

#### When the max-width is fixed and the background color is white, both ends appear to be cut off.

<table>
  <tr>
    <th>BEFORE</th>
    <th>AFTER</th>
  </tr>
  <tr>
    <td>
      <img width="773" alt="スクリーンショット 2021-01-13 14 12 26" src="https://media.git.pepabo.com/user/140/files/3829d900-55aa-11eb-84f9-6d62aafc1cff">
    </td>
    <td>
      <img width="750" alt="スクリーンショット 2021-01-13 14 13 09" src="https://media.git.pepabo.com/user/140/files/3d872380-55aa-11eb-8725-fff6245b372c">
    </td>
  </tr>
</table>

#### It's very systematic.

It has a system-like feel because it is made according to Material Design guidelines. By adding roundness, I want to add a flavor of Nachiguro's ease and kindness.

<table>
  <tr>
    <th>BEFORE</th>
    <th>AFTER</th>
  </tr>
  <tr>
    <td>
      <img width="433" alt="スクリーンショット 2021-01-13 14 14 16" src="https://media.git.pepabo.com/user/140/files/6c9d9500-55aa-11eb-8637-dfaefa756884">
    </td>
    <td>
      <img width="414" alt="スクリーンショット 2021-01-13 14 13 47" src="https://media.git.pepabo.com/user/140/files/70c9b280-55aa-11eb-8b6d-74e9bee67005">
    </td>
  </tr>
</table>

In addition, the hover color is not reflected when in dark mode, which is also fixed.