### PR TITLE
Align the start position of the Label with the start position of the value

### DIFF
--- a/src/components/_textfield.scss
+++ b/src/components/_textfield.scss
@@ -158,6 +158,7 @@ error・successの場合は以下のようにマークアップします。
   top: 0;
   z-index: 2;
   line-height: 6px;
+  margin-left: 4px;
 }
 
 .ncgr-textfield__required-label {


### PR DESCRIPTION
Align the start position of the Label with the start position of the value.

<table>
  <tr>
    <th>BEFORE</th>
    <th>AFTER</th>
  </tr>
  <tr>
    <td>
      <img width="386" alt="スクリーンショット 2021-01-04 20 50 18" src="https://user-images.githubusercontent.com/945841/103532371-7a7a5880-4ece-11eb-93b7-2d2b4bc7cc81.png">
    </td>
    <td>
      <img width="382" alt="スクリーンショット 2021-01-04 20 50 11" src="https://user-images.githubusercontent.com/945841/103532385-80703980-4ece-11eb-9686-1f27d0c6fa0b.png">
    </td>
  </tr>
</table>