### PR TITLE
Update disabled checkboox style

### DIFF
--- a/src/components/_checkbox.scss
+++ b/src/components/_checkbox.scss
@@ -37,7 +37,15 @@ category: Components
   <input type="checkbox" name="hoge" disabled="disabled">
   <span>
     <i class="fas fa-check"></i>
-    否
+    選択禁止（未選択）
+  </span>
+</label>
+
+<label class="ncgr-checkbox">
+  <input type="checkbox" name="hoge" checked disabled="disabled">
+  <span>
+    <i class="fas fa-check"></i>
+    選択禁止（選択済み）
   </span>
 </label>
 ```
@@ -73,7 +81,15 @@ category: Components
   <input type="checkbox" name="hoge" disabled="disabled">
   <span>
     <i class="fas fa-check"></i>
-    否
+    選択禁止（未選択）
+  </span>
+</label>
+
+<label class="ncgr-checkbox ncgr-checkbox--vertical">
+  <input type="checkbox" name="hoge" checked disabled="disabled">
+  <span>
+    <i class="fas fa-check"></i>
+    選択禁止（選択済み）
   </span>
 </label>
 ```
@@ -155,9 +171,18 @@ category: Components
 
   input:disabled + span {
     cursor: not-allowed;
+    color: var(--color-default-200);
     &::before {
-      background: var(--color-default-75);
-      border-color: var(--color-default-75);
+      opacity: 0.3;
+    }
+  }
+
+  input:checked:disabled + span {
+    cursor: not-allowed;
+    color: var(--color-default-200);
+    &::before {
+      background: var(--color-default-200);
+      border-color: var(--color-default-200);
     }
     i {
       color: var(--color-white);

--- a/src/components/_checkbox.scss
+++ b/src/components/_checkbox.scss
@@ -32,6 +32,14 @@ category: Components
     その他
   </span>
 </label>
+
+<label class="ncgr-checkbox">
+  <input type="checkbox" name="hoge" disabled="disabled">
+  <span>
+    <i class="fas fa-check"></i>
+    否
+  </span>
+</label>
 ```
 
 縦に並べる場合には、以下のようにマークアップします。
@@ -58,6 +66,14 @@ category: Components
   <span>
     <i class="fas fa-check"></i>
     その他
+  </span>
+</label>
+
+<label class="ncgr-checkbox ncgr-checkbox--vertical">
+  <input type="checkbox" name="hoge" disabled="disabled">
+  <span>
+    <i class="fas fa-check"></i>
+    否
   </span>
 </label>
 ```
@@ -138,8 +154,16 @@ category: Components
   }
 
   input:disabled + span {
+    cursor: not-allowed;
     &::before {
-      opacity: 0.3;
+      background: var(--color-default-75);
+      border-color: var(--color-default-75);
+    }
+    i {
+      color: var(--color-white);
+    }
+    svg {
+      fill-opacity: 1;
     }
   }
 }


### PR DESCRIPTION
I updated the states of checkbox below to make them more distinguishable.
- unselected and disabled
- selected and disabled

<img width="676" alt="スクリーンショット 2021-02-12 14 10 12" src="https://user-images.githubusercontent.com/21121644/107732565-09835780-6d3c-11eb-8842-219ae6c85885.png">

Currently ↓ ( left: selected and disabled, right: unselected and disabled )
<img width="224" alt="スクリーンショット 2021-02-26 12 40 02" src="https://user-images.githubusercontent.com/21121644/109252004-d8bd1b00-782f-11eb-9e5e-33ed543737db.png">

