### PR TITLE
Fix Expansion-List-View

### DIFF
--- a/src/components/_list-view.scss
+++ b/src/components/_list-view.scss
@@ -786,7 +786,7 @@ $list-view-gaps: $gaps;
 .ncgr-list-tile__expansion-checkbox ~ .ncgr-list-tile__expansion-body {
   overflow: hidden;
   max-height: 0;
-  transition: max-height 0.4s ease;
+  transition: max-height 0.4s ease, padding 0s ease 0.4s;
   padding: 0;
 }
 

--- a/src/components/_list-view.scss
+++ b/src/components/_list-view.scss
@@ -18,7 +18,6 @@ category: Components
 また、`.ncgr-list-view`に`-dense`のmodifierを付与すると、リストの上下paddingが半分のサイズになります。
 
 少ない情報からさらに詳しい情報を見せたい場合には、伸縮するカードを生成できる`Expansion List`のオプションを使用してください。
-`Expansion List`を使用する際は、ひとつの`ncgr-list-view`の中にひとつの`ncgr-list-tile__expansion-body`を置くようにしてください。
 
 ```example
 <section class="ncgr-list-group">


### PR DESCRIPTION
Fix probrem that padding of `ncgr-list-view__expansion-body` breaks when Expansion List is closed.