### PR TITLE
Fix Selectbox label position

### DIFF
--- a/src/components/_selectbox.scss
+++ b/src/components/_selectbox.scss
@@ -94,6 +94,7 @@ category: Components
   top: -2px;
   z-index: 2;
   line-height: 6px;
+  margin-left: -2px;
 }
 
 .ncgr-selectbox--prefecture-code {


### PR DESCRIPTION
Fix Selectbox label position.

Align to the same location as the textfield.