### PR TITLE
Add cursor pointer to Select box

### DIFF
--- a/src/components/_selectbox.scss
+++ b/src/components/_selectbox.scss
@@ -30,6 +30,7 @@ category: Components
   border-radius: 8px;
   border: 2px solid rgba(var(--color-textfield-separator), 0.15);
   box-sizing: border-box;
+  cursor: pointer;
   select {
     appearance: none;
     -webkit-appearance: none;


### PR DESCRIPTION
In case we don't use select tag, `cursor: pointer` is needed in `.ncgr-selectbox`.