### PR TITLE
Fix alert component

### DIFF
--- a/src/components/_alert.scss
+++ b/src/components/_alert.scss
@@ -343,7 +343,12 @@ $colors: default, primary, success, warning, danger;
       color: var(--color-#{$color}-900);
       &.-appearance-white {
         background-color: var(--color-secondary-grouped-background);
-        color: var(--color-label);
+        @media (prefers-color-scheme: dark) {
+          color: var(--color-#{$color}-200);
+        }
+        &.-color-default{
+          color: var(--color-label);
+        }
       }
       &.-appearance-flat {
         background-color: var(--color-#{$color}-50);


### PR DESCRIPTION
- safari は img に `width: 100%` がないと崩れるようでした
- dark mode で appearance-white を用いた場合の考慮が抜けていた

dark mode廃止対応とコンフリクトしてしまい申し訳ないです🙇🏻‍♂️ 
具体的に本番で崩れているのはトリブンのfreenance部分です。

|before|after|
|---|---|
|<img width="300" alt="スクリーンショット 2021-08-26 12 03 48" src="https://user-images.githubusercontent.com/21121644/130893823-c51edcd9-85a0-4cd7-9ea9-0f021d8782f0.png">|<img width="300" alt="スクリーンショット 2021-08-26 12 03 56" src="https://user-images.githubusercontent.com/21121644/130893833-a8530e08-8d04-4784-ad5a-2c97bbc711f6.png">|
