### PR TITLE
ButtonのOutlinedの見た目をNachiguro独自に調整する

### DIFF
--- a/src/@inhouse/flavor/variables/_color.scss
+++ b/src/@inhouse/flavor/variables/_color.scss
@@ -237,7 +237,7 @@ $button-color: (
   negative:    nachiguro-color.color(red, 500),
   attention:   nachiguro-color.color(orange, 500),
   interactive: nachiguro-color.color(blue, 600),
-  favorite:    nachiguro-color.color(red, 500),
+  favorite:    nachiguro-color.color(red, 400),
 ) !default;
 
 $checkbox-color: nachiguro-color.color(blue, 600) !default;

--- a/src/components/_botan.scss
+++ b/src/components/_botan.scss
@@ -234,7 +234,7 @@ Leadingのみにしてアイコンのみのボタンにすることもできま�
 
   // NachiguroのユースケースだとOutlinedのborder-colorはintentionの影響がない単純なStroke Colorがよい
   &.-appearance-outlined {
-    border-color: adapter.get-color(gray, 400);
+    border-color: adapter.get-color(gray, 200) !important;
   }
 }
 

--- a/src/components/_botan.scss
+++ b/src/components/_botan.scss
@@ -220,6 +220,7 @@ Leadingのみにしてアイコンのみのボタンにすることもできま�
 // TODO: 全部置き換えできたら名前をbotanからbuttonにする
 
 @use '@inhouse/button/mixins';
+@use '@inhouse/adapter/functions' as adapter;
 
 .ncgr-botan {
   @include mixins.style((
@@ -230,6 +231,11 @@ Leadingのみにしてアイコンのみのボタンにすることもできま�
     shape: square,
     width: auto,
   ));
+
+  // NachiguroのユースケースだとOutlinedのborder-colorはintentionの影響がない単純なStroke Colorがよい
+  &.-appearance-outlined {
+    border-color: adapter.get-color(gray, 400);
+  }
 }
 
 .ncgr-apple-botan {


### PR DESCRIPTION
<img width="131" alt="スクリーンショット 2021-11-25 18 39 18" src="https://user-images.githubusercontent.com/945841/143417097-405bbe4a-b326-4462-bba6-5e1afbb0e878.png">

- Favoriteのボタン色を変更します。
- ButtonのOutlinedの見た目をNachiguro独自に調整します。
  - Inhouse本体にFlavorで設定できるようにしようかなとも思ったけど他のサービスでの需要がなさそうなので独自カスタムします。