### PR TITLE
app-barは--activatedで表示する

### DIFF
--- a/src/components/_app-bar.scss
+++ b/src/components/_app-bar.scss
@@ -12,7 +12,7 @@ category: Components
 さらに、ナビゲーションを行うこともできます。Headerが逆方向の遷移のみ行えるのに対し、App BarはMenuアイコンのButtonのクリックイベントでNavigation系のコンポーネント（Side NavigationまたはNavigation Drawer）を開閉し、横方向の画面遷移を行えます。
 
 ```example
-<header class="ncgr-app-bar -appearance-white -brightness-light -position-static">
+<header class="ncgr-app-bar -appearance-white -brightness-light -position-static --activated">
   <div class="_navigation">
     <button aria-label="More" class="ncgr-botan -appearance-transparent -shape-circle">
       <div class="_leading">
@@ -48,5 +48,11 @@ category: Components
 
 .ncgr-app-bar {
   @include mixins.style();
+
+  display: none;
+
+  &.--activated {
+    display: flex;
+  }
 }
 


### PR DESCRIPTION
- 現状のSUZURIだとSemi Modalのように複数のapp-barを持つ場合、--activatedで表示するという仕様があるので、一旦`--activated`がついているときのみ表示するようにします。
- Modal系のコンポーネントをInhouseのコンポーネントに置き換えたら削除します。