### PR TITLE
Provide nachiguro/adapter as a proxy layer of @inhouse/adapter

### DIFF
--- a/_adapter.scss
+++ b/_adapter.scss
@@ -1,3 +1,3 @@
 // adapterは、nachiguro-flavorが適用された@inhouse/adapterを再エクスポートするレイヤーです。
-// Nachiguroの利用者がInhouseを直接触らず 'nachiguro/src/adapter'を使うようにするためのものです。
+// Nachiguroの利用者がInhouseを直接触らず 'nachiguro/adapter'を使うようにするためのものです。
 @forward '@inhouse/adapter';

--- a/src/_adapter.scss
+++ b/src/_adapter.scss
@@ -1,0 +1,3 @@
+// adapterは、nachiguro-flavorが適用された@inhouse/adapterを再エクスポートするレイヤーです。
+// Nachiguroの利用者がInhouseを直接触らず 'nachiguro/src/adapter'を使うようにするためのものです。
+@forward '@inhouse/adapter';


### PR DESCRIPTION
Provide nachiguro/adapter as a proxy layer of @inhouse/adapter (just re-exporting).
Any user of nachiguro should be Inhouse-agnostic and just `@use 'nachiguro/adapter' as adapter;`