### PR TITLE
Fix text field

### DIFF
--- a/src/components/_text-field.scss
+++ b/src/components/_text-field.scss
@@ -46,7 +46,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -126,7 +128,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -137,7 +141,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -149,7 +155,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -161,7 +169,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -173,7 +183,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -246,7 +258,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -258,7 +272,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -270,7 +286,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -331,7 +349,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -343,7 +363,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -355,7 +377,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -429,7 +453,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -441,7 +467,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -453,7 +481,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -465,7 +495,9 @@ category: Components
       <option value="02">人間</option>
     </select>
     <div class="_trailing">
-      <span class="ncgr-icon _icon" data-icon="arrow_drop_down"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="arrow_drop_down"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -483,7 +515,9 @@ Iconには`_icon`クラスを付与します。
 <div class="ncgr-text-field -size-xs">
   <div class="_control">
     <div class="_leading">
-      <span class="ncgr-icon _icon" data-icon="magnifying_glass"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="magnifying_glass"></span>
+      </div>
     </div>
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
   </div>
@@ -491,7 +525,9 @@ Iconには`_icon`クラスを付与します。
 <div class="ncgr-text-field -size-s">
   <div class="_control">
     <div class="_leading">
-      <span class="ncgr-icon _icon" data-icon="magnifying_glass"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="magnifying_glass"></span>
+      </div>
     </div>
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
   </div>
@@ -500,7 +536,9 @@ Iconには`_icon`クラスを付与します。
   <label class="_label" for="name">名前</label>
   <div class="_control">
     <div class="_leading">
-      <span class="ncgr-icon _icon" data-icon="magnifying_glass"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="magnifying_glass"></span>
+      </div>
     </div>
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
   </div>
@@ -509,7 +547,9 @@ Iconには`_icon`クラスを付与します。
   <label class="_label" for="name">名前</label>
   <div class="_control">
     <div class="_leading">
-      <span class="ncgr-icon _icon" data-icon="magnifying_glass"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="magnifying_glass"></span>
+      </div>
     </div>
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
   </div>
@@ -518,7 +558,9 @@ Iconには`_icon`クラスを付与します。
   <label class="_label" for="name">名前</label>
   <div class="_control">
     <div class="_leading">
-      <span class="ncgr-icon _icon" data-icon="magnifying_glass"></span>
+      <div class="_icon">
+        <span class="ncgr-icon" data-icon="magnifying_glass"></span>
+      </div>
     </div>
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
   </div>
@@ -598,7 +640,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-positive" data-icon="check"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-positive" data-icon="check"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -606,7 +650,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-positive" data-icon="check"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-positive" data-icon="check"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -615,7 +661,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-positive" data-icon="check"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-positive" data-icon="check"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -624,7 +672,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-positive" data-icon="check"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-positive" data-icon="check"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -633,7 +683,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-positive" data-icon="check"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-positive" data-icon="check"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -644,7 +696,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -652,7 +706,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -661,7 +717,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -670,7 +728,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      <div class="_icon">
+        <span class="ncgr-icon _icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -679,7 +739,9 @@ Iconには`_icon`クラスを付与します。
   <div class="_control">
     <input class="_input" type="text" name="name" placeholder="スリスリ君">
     <div class="_trailing">
-      <span class="ncgr-icon _icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      <div class="_icon">
+        <span class="ncgr-icon -color-negative" data-icon="exclamation_on_triangle"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -1076,6 +1138,13 @@ $default-options: (
       align-items: center;
 
       & > ._icon,
+      & > ._text,
+      & > ._button {
+        display: flex;
+        align-items: center;
+      }
+
+      & > ._icon,
       & > ._text {
         color: $text-field-edge-element-text-color;
         font-size:
@@ -1083,17 +1152,12 @@ $default-options: (
             $level: map.get($options, size)
           );
       }
-      
-      & > ._button {
-        display: flex;
-        align-items: center;
-      }
     }
 
     & > ._trailing {
       & > ._icon {
         @each $color in adapter.get-semantic-intentions() {
-          &.-color-#{$color} {
+          & > *.-color-#{$color} {
             color:
               adapter.get-semantic-color(
                 $intention: $color,


### PR DESCRIPTION
TextfieldのElementをIconと蜜に結合させると取り回しがききにくいので、`.ncgr-icon` に直接 `_icon` をつけるのではなく一個divをかまします。