### PR TITLE
App Bar内のBadgeがitem内にとどまるようにする

### DIFF
--- a/src/components/_app-bar.scss
+++ b/src/components/_app-bar.scss
@@ -68,5 +68,14 @@ category: Components
   &.--activated {
     display: flex;
   }
+
+  // BadgeがInhouseに実装されてButtonにつけられるようになったら消す
+  & > ._trailing {
+    ._list {
+      ._item {
+        position: relative;
+      }
+    }
+  }
 }
 


### PR DESCRIPTION
App Bar内のBadgeがitem内にとどまるようにします。
Inhouse側の実装がされるまでの暫定処置です。

これをいれないとカートのBadgeがこのように飛んでしまいます。
<img width="365" alt="スクリーンショット 2022-02-17 12 03 11" src="https://user-images.githubusercontent.com/945841/154396774-7df99800-23ab-438c-bc30-d66652671d59.png">

