### PR TITLE
CardのCoverが画像によって境界がわかりづらくなる場合があるので、下にborderを引く

### DIFF
--- a/src/components/_card.scss
+++ b/src/components/_card.scss
@@ -109,6 +109,7 @@ category: Components
   border-radius: 8px 8px 0 0;
   background-color: var(--color-default-75);
   width: 100%;
+  border-bottom: 1px solid var(--color-separator);
 }
 
 .ncgr-card__cover--white {


### PR DESCRIPTION
CardのCoverが画像によって境界がわかりづらくなる場合があるので、下にborderを引きます。
<img width="1570" alt="スクリーンショット 2022-03-04 11 46 46" src="https://user-images.githubusercontent.com/945841/156689444-1754d964-f213-427d-aecf-504ab06260cf.png">

